### PR TITLE
Refactor absolute image paths to relative

### DIFF
--- a/module/generator/scvmfactory.js
+++ b/module/generator/scvmfactory.js
@@ -275,7 +275,7 @@ function randomNumberedFile(dir, prefix, maxImgNum, extension) {
   const imgNum = randomIntFromInterval(1, maxImgNum);
   // format to 2 digits
   const imgNumStr = imgNum.toLocaleString('en-US', {minimumIntegerDigits: 2, useGrouping:false});
-  return `/${dir}/${prefix}${imgNumStr}.${extension}`;
+  return `${dir}/${prefix}${imgNumStr}.${extension}`;
 };
 
 function randomCharacterPortrait() {

--- a/templates/actor/abilities.html
+++ b/templates/actor/abilities.html
@@ -2,7 +2,7 @@
   <div class="widget ability-row">
     <div class="ability-icon">
       <a class="ability-link" data-ability="strength" title="{{ localize 'CY.Strength' }}">
-        <img src="/systems/cy-borg/assets/images/ui/icon_strength.png" />
+        <img src="systems/cy-borg/assets/images/ui/icon_strength.png" />
         <div class="ability-label">{{ localize 'CY.StrengthAbbrev' }}</div>
       </a>
     </div>
@@ -13,7 +13,7 @@
   <div class="widget ability-row">
     <div class="ability-icon">
       <a class="ability-link" data-ability="agility" title="{{ localize 'CY.Agility' }}">
-        <img src="/systems/cy-borg/assets/images/ui/icon_agility.png" />
+        <img src="systems/cy-borg/assets/images/ui/icon_agility.png" />
         <div class="ability-label">{{ localize 'CY.AgilityAbbrev' }}</div>        
       </a>
     </div>
@@ -24,7 +24,7 @@
   <div class="widget ability-row">
     <div class="ability-icon">
       <a class="ability-link" data-ability="presence" title="{{ localize 'CY.Presence' }}">
-        <img src="/systems/cy-borg/assets/images/ui/icon_presence.png" />
+        <img src="systems/cy-borg/assets/images/ui/icon_presence.png" />
         <div class="ability-label">{{ localize 'CY.PresenceAbbrev' }}</div>
       </a>
     </div>
@@ -35,7 +35,7 @@
   <div class="widget ability-row">
     <div class="ability-icon">
       <a class="ability-link" data-ability="toughness" title="{{ localize 'CY.Toughness' }}">
-        <img src="/systems/cy-borg/assets/images/ui/icon_toughness.png" />
+        <img src="systems/cy-borg/assets/images/ui/icon_toughness.png" />
         <div class="ability-label">{{ localize 'CY.ToughnessAbbrev' }}</div>        
       </a>
     </div>
@@ -46,7 +46,7 @@
   <div class="widget ability-row">
     <div class="ability-icon">
       <a class="ability-link" data-ability="knowledge" title="{{ localize 'CY.Knowledge' }}">
-        <img src="/systems/cy-borg/assets/images/ui/icon_knowledge.png" />
+        <img src="systems/cy-borg/assets/images/ui/icon_knowledge.png" />
         <div class="ability-label">{{ localize 'CY.KnowledgeAbbrev' }}</div>
       </a>
     </div>
@@ -59,7 +59,7 @@
   <!-- <div class="widget ability-row">
     <div class="ability-icon">
       <a class="ability-link" data-ability="glitches" title="{{ localize 'CY.Glitches' }}">
-        <img src="/systems/cy-borg/assets/images/ui/icon_glitches.png" />
+        <img src="systems/cy-borg/assets/images/ui/icon_glitches.png" />
       </a>
     </div>
     <div class="ability-score">


### PR DESCRIPTION
Hey @mcglincy not sure if you're open to pull requests, but I wanted to fix an issue I ran into while setting this up on my foundry instance.

I self-host multiple foundry instances through a proxy server that routes to a specific instance on a path prefix like `/v12.x/1`.

Absolute image paths break because the expected resources aren't available on the host path, so we need to use relative image paths.

I see relative paths are being used elsewhere, so hopefully this doesn't create issues. Let me know what you think!