### PR TITLE
Party Initiative

### DIFF
--- a/module/combat/combat.js
+++ b/module/combat/combat.js
@@ -58,11 +58,14 @@ export class CYCombatModel extends foundry.abstract.TypeDataModel {
       return null;
     }
 
+    let result;
     if (isFriendly) {
-      return this.partyInitiative >= 4;
+      result = this.partyInitiative >= 4;
     } else {
-      return this.partyInitiative <= 3;
+      result = this.partyInitiative <= 3;
     }
+
+    return result ? 1 : 0;
   }
 }
 

--- a/module/combat/combat.js
+++ b/module/combat/combat.js
@@ -12,7 +12,7 @@ export class CYCombatModel extends foundry.abstract.TypeDataModel {
   async setPartyInitiative(rollTotal) {
     this.partyInitiative = rollTotal;
     await this.setCombatantsInitiative();
-    // Update system state last since this will construct a new instance of this class
+    // Update parent state last since this will construct a new instance of this class
     await this.parent.update({ "system.partyIntiative": rollTotal });
   }
 

--- a/module/combat/combat.js
+++ b/module/combat/combat.js
@@ -4,19 +4,17 @@ export class CYCombat extends Combat {
     await game.combat.resortCombatants();
   }
 
-  async resortCombatants() {
-    // TODO: this seems like a stupidly-hacky way to do this. Is there no better way?
+  async setCombatantsInitiative() {
     const updates = this.turns.map((t) => {
       return {
         _id: t.id,
-        initiative: t.system.initiative,
+        initiative: this.#getInitiative(t),
       };
     });
-    await game.combat.resetAll();
     await this.updateEmbeddedDocuments("Combatant", updates);
   }
 
-  isFriendlyCombatant(combatant) {
+  #isFriendlyCombatant(combatant) {
     if (combatant._token) {
       // v8 compatible
       return combatant._token.system.disposition === 1;
@@ -30,37 +28,49 @@ export class CYCombat extends Combat {
     return false;
   }
 
-  /**
-   * Define how the array of Combatants is sorted in the displayed list of the tracker.
-   * This method can be overridden by a system or module which needs to display combatants in an alternative order.
-   * By default sort by initiative, falling back to name
-   * @private
-   */
-  _sortCombatants(a, b) {
-    // .combat is a getter, so verify existence of combats array
-    if (game.combats && game.combat.partyInitiative) {
-      const isPartyA = game.combat.isFriendlyCombatant(a);
-      const isPartyB = game.combat.isFriendlyCombatant(b);
-      if (isPartyA !== isPartyB) {
-        // only matters if they're different
-        if (game.combat.partyInitiative > 3) {
-          // players begin
-          return isPartyA ? -1 : 1;
-        } else {
-          // enemies begin
-          return isPartyA ? 1 : -1;
-        }
-      }
+  #getInitiative(combatant) {
+    if (this.partyInitiative == null) {
+      return null;
     }
 
-    // combatants are both friendly or enemy, so sort by normal initiative
-    const ia = Number.isNumeric(a.initiative) ? a.initiative : -9999;
-    const ib = Number.isNumeric(b.initiative) ? b.initiative : -9999;
-    const ci = ib - ia;
-    if (ci !== 0) return ci;
-    const [an, bn] = [a.token?.name || "", b.token?.name || ""];
-    const cn = an.localeCompare(bn);
-    if (cn !== 0) return cn;
-    return a.tokenId - b.tokenId;
+    if (this.#isFriendlyCombatant(combatant)) {
+      return this.partyInitiative >= 4;
+    } else {
+      return this.partyInitiative <= 3;
+    }
   }
+
+  // /**
+  //  * Define how the array of Combatants is sorted in the displayed list of the tracker.
+  //  * This method can be overridden by a system or module which needs to display combatants in an alternative order.
+  //  * By default sort by initiative, falling back to name
+  //  * @private
+  //  */
+  // _sortCombatants(a, b) {
+  //   // .combat is a getter, so verify existence of combats array
+  //   if (game.combats && game.combat?.partyInitiative) {
+  //     const isPartyA = game.combat.isFriendlyCombatant(a);
+  //     const isPartyB = game.combat.isFriendlyCombatant(b);
+  //     if (isPartyA !== isPartyB) {
+  //       // only matters if they're different
+  //       if (game.combat.partyInitiative > 3) {
+  //         // players begin
+  //         return isPartyA ? -1 : 1;
+  //       } else {
+  //         // enemies begin
+  //         return isPartyA ? 1 : -1;
+  //       }
+  //     }
+  //   }
+
+  //   // combatants are both friendly or enemy, so sort by normal initiative
+  //   const ia = Number.isNumeric(a.initiative) ? a.initiative : -9999;
+  //   const ib = Number.isNumeric(b.initiative) ? b.initiative : -9999;
+  //   const ci = ib - ia;
+  //   if (ci !== 0) return ci;
+  //   const [an, bn] = [a.token?.name || "", b.token?.name || ""];
+  //   const cn = an.localeCompare(bn);
+  //   if (cn !== 0) return cn;
+  //   return a.tokenId - b.tokenId;
+  // }
 }

--- a/module/combat/combat.js
+++ b/module/combat/combat.js
@@ -1,7 +1,7 @@
 export class CYCombat extends Combat {
   async setPartyInitiative(rollTotal) {
     game.combat.partyInitiative = rollTotal;
-    await game.combat.resortCombatants();
+    await game.combat.setCombatantsInitiative();
   }
 
   async setCombatantsInitiative() {

--- a/module/combat/combat.js
+++ b/module/combat/combat.js
@@ -1,3 +1,5 @@
+import { rollPartyInitiative } from "./initiative";
+
 export class CYCombat extends Combat {
   async setPartyInitiative(rollTotal) {
     game.combat.partyInitiative = rollTotal;
@@ -38,6 +40,32 @@ export class CYCombat extends Combat {
     } else {
       return this.partyInitiative <= 3;
     }
+  }
+
+  /**
+   * @override
+   */
+  async rollInitiative(ids, { updateTurn = true } = {}) {
+    const [id] = ids;
+    const currentId = this.combatant?.id;
+    if (!id) {
+      return;
+    }
+
+    const combatant = this.combatants.get(id);
+    if (!combatant) {
+      return;
+    }
+
+    await rollPartyInitiative(combatant.actor);
+
+    if (updateTurn && currentId) {
+      await this.update({
+        turn: this.turns.findIndex((t) => t.id === currentId),
+      });
+    }
+
+    return this;
   }
 
   // /**

--- a/module/combat/combat.js
+++ b/module/combat/combat.js
@@ -1,4 +1,4 @@
-import { rollPartyInitiative } from "./initiative";
+import { rollPartyInitiative } from "./initiative.js";
 
 export class CYCombat extends Combat {
   async setPartyInitiative(rollTotal) {

--- a/module/combat/combat.js
+++ b/module/combat/combat.js
@@ -10,7 +10,7 @@ export class CYCombatModel extends foundry.abstract.TypeDataModel {
   }
 
   async setPartyInitiative(rollTotal) {
-    await this.parent.update({ "system.partyInitiative": rollTotal });
+    this.partyInitiative = rollTotal;
     await this.setCombatantsInitiative();
   }
 

--- a/module/combat/combat.js
+++ b/module/combat/combat.js
@@ -12,6 +12,8 @@ export class CYCombatModel extends foundry.abstract.TypeDataModel {
   async setPartyInitiative(rollTotal) {
     this.partyInitiative = rollTotal;
     await this.setCombatantsInitiative();
+    // Update system state last since this will construct a new instance of this class
+    await this.parent.update({ "system.partyIntiative": rollTotal });
   }
 
   async setCombatantsInitiative() {

--- a/module/combat/combat.js
+++ b/module/combat/combat.js
@@ -68,7 +68,7 @@ export class CYCombatModel extends foundry.abstract.TypeDataModel {
 
 export class CYCombat extends Combat {
   /**
-   * @override
+   * @inheritdoc
    */
   async create(data = {}, operation) {
     // Always create with type: 'cy' so we can use the CYCombatModel
@@ -76,9 +76,11 @@ export class CYCombat extends Combat {
   }
 
   /**
+   * Rolls party initiative for the combat
    * @override
    */
   async rollInitiative(ids, { updateTurn = true } = {}) {
+    // We only need to roll intiative once for all combatants, so grab the first id
     const [id] = ids;
     const currentId = this.combatant?.id;
     if (!id) {
@@ -102,7 +104,7 @@ export class CYCombat extends Combat {
   }
 
   /**
-   * @override
+   * @inheritdoc
    */
   async createEmbeddedDocuments(embeddedName, data = [], operation = {}) {
     return super.createEmbeddedDocuments(

--- a/module/combat/combat.js
+++ b/module/combat/combat.js
@@ -67,38 +67,4 @@ export class CYCombat extends Combat {
 
     return this;
   }
-
-  // /**
-  //  * Define how the array of Combatants is sorted in the displayed list of the tracker.
-  //  * This method can be overridden by a system or module which needs to display combatants in an alternative order.
-  //  * By default sort by initiative, falling back to name
-  //  * @private
-  //  */
-  // _sortCombatants(a, b) {
-  //   // .combat is a getter, so verify existence of combats array
-  //   if (game.combats && game.combat?.partyInitiative) {
-  //     const isPartyA = game.combat.isFriendlyCombatant(a);
-  //     const isPartyB = game.combat.isFriendlyCombatant(b);
-  //     if (isPartyA !== isPartyB) {
-  //       // only matters if they're different
-  //       if (game.combat.partyInitiative > 3) {
-  //         // players begin
-  //         return isPartyA ? -1 : 1;
-  //       } else {
-  //         // enemies begin
-  //         return isPartyA ? 1 : -1;
-  //       }
-  //     }
-  //   }
-
-  //   // combatants are both friendly or enemy, so sort by normal initiative
-  //   const ia = Number.isNumeric(a.initiative) ? a.initiative : -9999;
-  //   const ib = Number.isNumeric(b.initiative) ? b.initiative : -9999;
-  //   const ci = ib - ia;
-  //   if (ci !== 0) return ci;
-  //   const [an, bn] = [a.token?.name || "", b.token?.name || ""];
-  //   const cn = an.localeCompare(bn);
-  //   if (cn !== 0) return cn;
-  //   return a.tokenId - b.tokenId;
-  // }
 }

--- a/module/combat/combat.js
+++ b/module/combat/combat.js
@@ -1,6 +1,3 @@
-
-
-
 export class CYCombat extends Combat {
   async setPartyInitiative(rollTotal) {
     game.combat.partyInitiative = rollTotal;
@@ -23,10 +20,14 @@ export class CYCombat extends Combat {
     if (combatant._token) {
       // v8 compatible
       return combatant._token.system.disposition === 1;
-    } else {
+    } else if (combatant.token.system?.disposition != null) {
       // v9+
       return combatant.token.system.disposition === 1;
+    } else if (combatant.token.disposition != null) {
+      // v12+
+      return combatant.token.disposition === 1;
     }
+    return false;
   }
 
   /**
@@ -63,5 +64,3 @@ export class CYCombat extends Combat {
     return a.tokenId - b.tokenId;
   }
 }
-
-

--- a/module/combat/combat.js
+++ b/module/combat/combat.js
@@ -72,7 +72,7 @@ export class CYCombat extends Combat {
    */
   async create(data = {}, operation) {
     // Always create with type: 'cy' so we can use the CYCombatModel
-    super.create({ ...data, type: "cy" }, operation);
+    return super.create({ ...data, type: "cy" }, operation);
   }
 
   /**

--- a/module/combat/combat.js
+++ b/module/combat/combat.js
@@ -13,7 +13,7 @@ export class CYCombatModel extends foundry.abstract.TypeDataModel {
     this.partyInitiative = rollTotal;
     await this.setCombatantsInitiative();
     // Update parent state last since this will construct a new instance of this class
-    await this.parent.update({ "system.partyIntiative": rollTotal });
+    await this.parent.update({ "system.partyInitiative": rollTotal });
   }
 
   async setCombatantsInitiative() {

--- a/module/combat/combat.js
+++ b/module/combat/combat.js
@@ -2,12 +2,21 @@ import { rollPartyInitiative } from "./initiative.js";
 
 const { NumberField } = foundry.data.fields;
 
-export class CYCombat extends Combat {
+export class CYCombatModel extends foundry.abstract.TypeDataModel {
   static defineSchema() {
     return {
-      ...super.defineSchema(),
       partyInitiative: new NumberField({ required: false, integer: true }),
     };
+  }
+}
+
+export class CYCombat extends Combat {
+  /**
+   * @override
+   */
+  async create(data = {}, operation) {
+    // Always create with type: 'cy' so we can use the CYCombatModel
+    super.create({ ...data, type: "cy" }, operation);
   }
 
   /**
@@ -55,7 +64,7 @@ export class CYCombat extends Combat {
   }
 
   async setPartyInitiative(rollTotal) {
-    await this.update({ partyInitiative: rollTotal });
+    await this.update({ system: { partyInitiative: rollTotal } });
     await this.setCombatantsInitiative();
   }
 

--- a/module/combat/combat.js
+++ b/module/combat/combat.js
@@ -10,7 +10,7 @@ export class CYCombatModel extends foundry.abstract.TypeDataModel {
   }
 
   async setPartyInitiative(rollTotal) {
-    await this.update({ partyInitiative: rollTotal });
+    await this.parent.update({ "system.partyInitiative": rollTotal });
     await this.setCombatantsInitiative();
   }
 

--- a/module/combat/combat.js
+++ b/module/combat/combat.js
@@ -64,7 +64,7 @@ export class CYCombat extends Combat {
   }
 
   async setPartyInitiative(rollTotal) {
-    await this.update({ system: { partyInitiative: rollTotal } });
+    await this.update({ "system.partyInitiative": rollTotal });
     await this.setCombatantsInitiative();
   }
 
@@ -97,14 +97,14 @@ export class CYCombat extends Combat {
   }
 
   #getInitiative(isFriendly) {
-    if (this.partyInitiative == null) {
+    if (this.system.partyInitiative == null) {
       return null;
     }
 
     if (isFriendly) {
-      return this.partyInitiative >= 4;
+      return this.system.partyInitiative >= 4;
     } else {
-      return this.partyInitiative <= 3;
+      return this.system.partyInitiative <= 3;
     }
   }
 }

--- a/module/combat/combat.js
+++ b/module/combat/combat.js
@@ -70,7 +70,7 @@ export class CYCombat extends Combat {
   /**
    * @inheritdoc
    */
-  async create(data = {}, operation) {
+  static async create(data = {}, operation) {
     // Always create with type: 'cy' so we can use the CYCombatModel
     return super.create({ ...data, type: "cy" }, operation);
   }

--- a/module/combat/combat.js
+++ b/module/combat/combat.js
@@ -1,6 +1,15 @@
 import { rollPartyInitiative } from "./initiative.js";
 
+const { NumberField } = foundry.data.fields;
+
 export class CYCombat extends Combat {
+  static defineSchema() {
+    return {
+      ...super.defineSchema(),
+      partyInitiative: new NumberField({ required: false, integer: true }),
+    };
+  }
+
   /**
    * @override
    */
@@ -46,8 +55,8 @@ export class CYCombat extends Combat {
   }
 
   async setPartyInitiative(rollTotal) {
-    game.combat.partyInitiative = rollTotal;
-    await game.combat.setCombatantsInitiative();
+    await this.update({ partyInitiative: rollTotal });
+    await this.setCombatantsInitiative();
   }
 
   async setCombatantsInitiative() {

--- a/module/combat/initiative.js
+++ b/module/combat/initiative.js
@@ -12,7 +12,7 @@ export async function rollPartyInitiative(actor) {
     outcomeText = game.i18n.localize("CY.InitiativePCsActFirst");
   }
   const rollResult = {
-    cardTitle: game.i18n.localize('CY.PartyInitiative'),
+    cardTitle: game.i18n.localize("CY.PartyInitiative"),
     formula: "1d6",
     roll: initiativeRoll,
     outcome: outcomeText,
@@ -21,10 +21,10 @@ export async function rollPartyInitiative(actor) {
 
   // if a combat/encounter is happening, apply player/enemy ordering
   if (game.combats && game.combat) {
-    await game.combat.setPartyInitiative(initiativeRoll.total);
+    await game.combat.system.setPartyInitiative(initiativeRoll.total);
   }
-};
-  
+}
+
 export async function rollIndividualInitiative(actor) {
   if (game.combats && game.combat) {
     // there is an encounter started in the Combat Tracker
@@ -47,9 +47,9 @@ export async function rollIndividualInitiative(actor) {
   await initiativeRoll.evaluate();
   await showDice(initiativeRoll);
   const rollResult = {
-    cardTitle: game.i18n.localize('CY.Initiative'),
+    cardTitle: game.i18n.localize("CY.Initiative"),
     formula: `1d6 + ${game.i18n.localize("CY.AgilityAbbrev")}`,
-    roll: initiativeRoll
+    roll: initiativeRoll,
   };
   showOutcomeRollCard(actor, rollResult);
-};
+}

--- a/module/cy-borg.js
+++ b/module/cy-borg.js
@@ -5,7 +5,7 @@ import { CYNpcSheet } from "./actor/npc-sheet.js";
 import { CYVehicleSheet } from "./actor/vehicle-sheet.js";
 import { CYItem } from "./item/item.js";
 import { CYItemSheet } from "./item/item-sheet.js";
-import { CYCombat } from "./combat/combat.js";
+import { CYCombat, CYCombatModel } from "./combat/combat.js";
 import { registerSystemSettings } from "./settings.js";
 import { showMakePunkDialog } from "./generator/make-punk-dialog.js";
 import { createNpc } from "./generator/scvmfactory.js";
@@ -53,6 +53,7 @@ const registerDocumentClasses = () => {
   CONFIG.Actor.documentClass = CYActor;
   CONFIG.Item.documentClass = CYItem;
   CONFIG.Combat.documentClass = CYCombat;
+  CONFIG.Combat.dataModels.cy = CYCombatModel;
 }
 
 const registerSheets = () => {

--- a/module/cy-borg.js
+++ b/module/cy-borg.js
@@ -5,6 +5,7 @@ import { CYNpcSheet } from "./actor/npc-sheet.js";
 import { CYVehicleSheet } from "./actor/vehicle-sheet.js";
 import { CYItem } from "./item/item.js";
 import { CYItemSheet } from "./item/item-sheet.js";
+import { CYCombat } from "./combat/combat.js";
 import { registerSystemSettings } from "./settings.js";
 import { showMakePunkDialog } from "./generator/make-punk-dialog.js";
 import { createNpc } from "./generator/scvmfactory.js";
@@ -51,6 +52,7 @@ const consoleBanner = () => {
 const registerDocumentClasses = () => {
   CONFIG.Actor.documentClass = CYActor;
   CONFIG.Item.documentClass = CYItem;
+  CONFIG.Combat.documentClass = CYCombat;
 }
 
 const registerSheets = () => {

--- a/system.json
+++ b/system.json
@@ -7,7 +7,7 @@
   "authors": [
     {
       "name": "mcglintlock"
-    }    
+    }
   ],
   "esmodules": ["module/cy-borg.js"],
   "styles": ["css/cy-borg.css"],
@@ -18,6 +18,11 @@
       "path": "lang/en.json"
     }
   ],
+  "documentTypes": {
+    "Combat": {
+      "cy": {}
+    }
+  },
   "packFolders": [
     {
       "name": "CY_BORG",
@@ -30,7 +35,7 @@
         "cyborg-tables"
       ]
     }
-  ],   
+  ],
   "packs": [
     {
       "name": "cyborg-actors",
@@ -38,7 +43,7 @@
       "system": "cy-borg",
       "path": "./packs/cyborg-actors",
       "type": "Actor"
-    },  
+    },
     {
       "name": "cyborg-items",
       "label": "CY_BORG (Items)",
@@ -67,7 +72,7 @@
       "path": "./packs/cyborg-tables",
       "type": "RollTable"
     }
-  ],  
+  ],
   "socket": true,
   "initiative": "1d6",
   "gridDistance": 10,
@@ -77,7 +82,7 @@
   "compatibility": {
     "minimum": "12",
     "verified": "12"
-  },  
+  },
   "url": "https://github.com/fvtt-fria-ligan/cyborg-foundry-vtt",
   "manifest": "https://github.com/fvtt-fria-ligan/cyborg-foundry-vtt/releases/latest/download/system.json",
   "download": "https://github.com/fvtt-fria-ligan/cyborg-foundry-vtt/releases/latest/download/system.zip"


### PR DESCRIPTION
Refactors and enables the party initiative system that will automatically set encounter order based on the party initiative roll results.

* Adds persisted document state for `partyInitiative` value
* Updates initiative logic to set values on combatants rather than using custom sorting logic
* Adds logic to check for party initiative when new combatants are added
* Overrides Combat behavior to roll party initiative instead of individual initiative