### PR TITLE
Fix: v12 weapon crits not visible in chat

### DIFF
--- a/module/combat/attack.js
+++ b/module/combat/attack.js
@@ -88,7 +88,7 @@ export async function rollAttack(
       damageFormula = `${damageFormula} * 2`;
     }
     if (isCrit) {
-      const critMultiplier = item.data.system.critMultiplier ?? 2;
+      const critMultiplier = item.system.critMultiplier ?? 2;
       damageFormula = `${damageFormula} * ${critMultiplier}`;
     }
     damageRoll = new Roll(damageFormula);


### PR DESCRIPTION
This fixes an issue where crits on weapon attacks wouldn't auto roll in chat due to `item.data.system` being depricated in favor of `item.system` in Foundry V12